### PR TITLE
fix(formatters/eslint_d): fix cli arguments

### DIFF
--- a/lua/efmls-configs/formatters/eslint_d.lua
+++ b/lua/efmls-configs/formatters/eslint_d.lua
@@ -1,7 +1,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'eslint_d'
-local args = '--fix-to-std --stdin --stdin-filename ${INPUT}'
+local args = '--fix-to-stdout --stdin'
 local command = string.format('%s %s', fs.executable(formatter, fs.Scope.NODE), args)
 
 return {


### PR DESCRIPTION
Doing a search on [the changelog for eslint_d](https://github.com/mantoni/eslint_d.js/blob/master/CHANGES.md) it looks like no option called `--fix-to-stdout` ever existed, so I'm not sure how/if this ever worked. Besides that, it appears like the `--stdin-filename` argument is not actually needed and this works fine without it.

I've verified this fix by installing from my fork instead and running `:lua vim.lsp.buf.formatting_sync()` - seems to do the trick!