### PR TITLE
feat(formatters/terraform_fmt): add formatter

### DIFF
--- a/lua/efmls-configs/formatters/terraform_fmt.lua
+++ b/lua/efmls-configs/formatters/terraform_fmt.lua
@@ -1,0 +1,10 @@
+local fs = require('efmls-configs.fs')
+
+local formatter = 'terraform'
+local args = 'fmt -'
+local command = string.format('%s %s', fs.executable(formatter), args)
+
+return {
+  formatCommand = command,
+  formatStdin = true,
+}

--- a/supported-linters-and-formatters.md
+++ b/supported-linters-and-formatters.md
@@ -1353,7 +1353,7 @@ Languages to support, list based on ALE with LSP servers omitted:
   + [ ] [stack-ghc](https://haskellstack.org/)
   + [ ] [stylish-haskell](https://github.com/jaspervdj/stylish-haskell)
 + HCL
-  + [ ] [terraform-fmt](https://github.com/hashicorp/terraform)
+  + [X] [terraform-fmt](https://github.com/hashicorp/terraform)
 + HTML
   + [X] [alex](https://github.com/wooorm/alex)
   + [X] [fecs](http://fecs.baidu.com/)


### PR DESCRIPTION
Does what it says on the tin: adds `terraform fmt` as a formatter. Passing `-` as the directory makes it accept input over stdin and output to stdout.