### PR TITLE
Don't use stdin for vint

### DIFF
--- a/lua/efmls-configs/linters/vint.lua
+++ b/lua/efmls-configs/linters/vint.lua
@@ -8,7 +8,7 @@ local command = string.format('%s %s %q', fs.executable(linter), args, format)
 return {
   prefix = linter,
   lintCommand = command,
-  lintStdin = true,
+  lintStdin = false,
   lintFormats = { '%f:%l:%c: %trror: %m', '%f:%l:%c: %tarning: %m' },
   rootMarkers = { '.vintrc.yaml', '.vintrc.yml', '.vintrc' },
 }


### PR DESCRIPTION
https://github.com/mattn/efm-langserver/issues/25

Alternatively, if one's using the master branch, it'd need `--stdin-display-name ${INPUT} -` but it seems like it's unmaintained and there won't be a release that supports that any time soon.