### PR TITLE
fix: require('health') is deprecated

### DIFF
--- a/lua/efmls-configs/health/init.lua
+++ b/lua/efmls-configs/health/init.lua
@@ -1,4 +1,3 @@
-local health = require('health')
 local M = {}
 
 local has_issues = function()
@@ -8,10 +7,10 @@ end
 M.check = function()
   if has_issues() then
     for _, issue in pairs(_G.efmls_healthcheck) do
-      health.report_error(issue)
+      vim.health.report_error(issue)
     end
   else
-    health.report_ok('All checks passed')
+    vim.health.report_ok('All checks passed')
   end
 end
 


### PR DESCRIPTION
In the new version, require('health') is replaced by vim.health.