### PR TITLE
fix(formatters/shfmt): pass in input filename

### DIFF
--- a/lua/efmls-configs/formatters/shfmt.lua
+++ b/lua/efmls-configs/formatters/shfmt.lua
@@ -1,7 +1,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'shfmt'
-local command = string.format('%s -', fs.executable(formatter))
+local command = string.format('%s -filename ${INPUT} -', fs.executable(formatter))
 
 return {
   formatCommand = command,


### PR DESCRIPTION
If `shfmt` doesn't have the input filename, it won't find `.editorconfig`.

Reference: https://github.com/mvdan/sh/issues/577