### PR TITLE
Pass filename to eslint and eslint_d.

### DIFF
--- a/lua/efmls-configs/formatters/eslint.lua
+++ b/lua/efmls-configs/formatters/eslint.lua
@@ -1,6 +1,6 @@
 local fs = require('efmls-configs.fs')
 
-local formatter = 'eslint_d'
+local formatter = 'eslint'
 local args = '--fix-to-stdout --stdin-filename ${INPUT} --stdin'
 local command = string.format('%s %s', fs.executable(formatter, fs.Scope.NODE), args)
 

--- a/lua/efmls-configs/formatters/eslint.lua
+++ b/lua/efmls-configs/formatters/eslint.lua
@@ -1,10 +1,10 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'eslint'
-local args = '--fix-to-stdout --stdin-filename ${INPUT} --stdin'
+local args = '--fix ${INPUT}'
 local command = string.format('%s %s', fs.executable(formatter, fs.Scope.NODE), args)
 
 return {
   formatCommand = command,
-  formatStdin = true,
+  formatStdin = false,
 }

--- a/lua/efmls-configs/linters/eslint.lua
+++ b/lua/efmls-configs/linters/eslint.lua
@@ -2,7 +2,7 @@ local fs = require('efmls-configs.fs')
 
 local linter = 'eslint'
 local bin = fs.executable(linter, fs.Scope.NODE)
-local args = '--no-color --format visualstudio --stdin'
+local args = '--no-color --format visualstudio --stdin-filename ${INPUT} --stdin'
 local command = string.format('%s %s', bin, args)
 
 return {

--- a/lua/efmls-configs/linters/eslint_d.lua
+++ b/lua/efmls-configs/linters/eslint_d.lua
@@ -2,7 +2,7 @@ local fs = require('efmls-configs.fs')
 
 local linter = 'eslint_d'
 local bin = fs.executable(linter, fs.Scope.NODE)
-local args = '--no-color --format visualstudio --stdin'
+local args = '--no-color --format visualstudio --stdin-filename ${INPUT} --stdin'
 local command = string.format('%s %s', bin, args)
 
 return {


### PR DESCRIPTION
* Without the filename, eslint cannot perform extension based overrides.
* Add missing eslint formatter.