### PR TITLE
 feat(formatter): Add smlfmt 

### DIFF
--- a/lua/efmls-configs/formatters/smlfmt.lua
+++ b/lua/efmls-configs/formatters/smlfmt.lua
@@ -5,7 +5,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'smlfmt'
-local command = string.format("%s --preview-only ${FILENAME} | sed '1d;$d'", fs.executable(formatter))
+local command = fs.executable(formatter)
 
 return {
   formatCommand = command,

--- a/lua/efmls-configs/formatters/smlfmt.lua
+++ b/lua/efmls-configs/formatters/smlfmt.lua
@@ -1,0 +1,13 @@
+-- Metadata
+-- languages: sml
+-- url: https://github.com/shwestrick/smlfmt
+
+local fs = require("efmls-configs.fs")
+
+local formatter = "smlfmt"
+local command = string.format("%s --preview-only ${FILENAME} | sed '1d;$d'", fs.executable(formatter))
+
+return {
+  formatCommand = command,
+  formatStdin = true,
+}

--- a/lua/efmls-configs/formatters/smlfmt.lua
+++ b/lua/efmls-configs/formatters/smlfmt.lua
@@ -2,9 +2,9 @@
 -- languages: sml
 -- url: https://github.com/shwestrick/smlfmt
 
-local fs = require("efmls-configs.fs")
+local fs = require('efmls-configs.fs')
 
-local formatter = "smlfmt"
+local formatter = 'smlfmt'
 local command = string.format("%s --preview-only ${FILENAME} | sed '1d;$d'", fs.executable(formatter))
 
 return {


### PR DESCRIPTION
`smlfmt` needlessly appends and prepends lines, hence the need for
`sed` deleting those lines.