### PR TITLE
Added fourmolu, gersemi, beautysh formatter and fixed cppcheck linter

### DIFF
--- a/doc/SUPPORTED_LIST.md
+++ b/doc/SUPPORTED_LIST.md
@@ -73,6 +73,68 @@ local vale = require('efmls-configs.linters.vale')
 local write_good = require('efmls-configs.linters.write_good')
 ```
 
+### Yaml
+
+#### Linters
+
+`actionlint` [https://github.com/rhysd/actionlint](https://github.com/rhysd/actionlint)
+
+```lua
+local actionlint = require('efmls-configs.linters.actionlint')
+```
+
+`ansible_lint` [https://github.com/willthames/ansible-lint](https://github.com/willthames/ansible-lint)
+
+```lua
+local ansible_lint = require('efmls-configs.linters.ansible_lint')
+```
+
+`yamllint` [https://yamllint.readthedocs.io/](https://yamllint.readthedocs.io/)
+
+```lua
+local yamllint = require('efmls-configs.linters.yamllint')
+```
+
+### Crystal
+
+#### Linters
+
+`ameba` [https://github.com/veelenga/ameba](https://github.com/veelenga/ameba)
+
+```lua
+local ameba = require('efmls-configs.linters.ameba')
+```
+
+### Bash
+
+#### Linters
+
+`bashate` [https://github.com/openstack/bashate](https://github.com/openstack/bashate)
+
+```lua
+local bashate = require('efmls-configs.linters.bashate')
+```
+
+`shellcheck` [https://www.shellcheck.net/](https://www.shellcheck.net/)
+
+```lua
+local shellcheck = require('efmls-configs.linters.shellcheck')
+```
+
+#### Formatters
+
+`beautysh` [https://github.com/illvart/beautysh-action](https://github.com/illvart/beautysh-action)
+
+```lua
+local beautysh = require('efmls-configs.formatters.beautysh')
+```
+
+`shfmt` [https://github.com/mvdan/sh](https://github.com/mvdan/sh)
+
+```lua
+local shfmt = require('efmls-configs.formatters.shfmt')
+```
+
 ### C
 
 #### Linters
@@ -193,6 +255,292 @@ local clang_tidy = require('efmls-configs.formatters.clang_tidy')
 local uncrustify = require('efmls-configs.formatters.uncrustify')
 ```
 
+### Clojure
+
+#### Linters
+
+`clj_kondo` [https://github.com/borkdude/clj-kondo](https://github.com/borkdude/clj-kondo)
+
+```lua
+local clj_kondo = require('efmls-configs.linters.clj_kondo')
+```
+
+`joker` [https://github.com/candid82/joker](https://github.com/candid82/joker)
+
+```lua
+local joker = require('efmls-configs.linters.joker')
+```
+
+#### Formatters
+
+`joker` [https://github.com/candid82/joker](https://github.com/candid82/joker)
+
+```lua
+local joker = require('efmls-configs.formatters.joker')
+```
+
+### Dart
+
+#### Linters
+
+`dartanalyzer` [https://github.com/dart-lang/sdk/tree/master/pkg/analyzer_cli](https://github.com/dart-lang/sdk/tree/master/pkg/analyzer_cli)
+
+```lua
+local dartanalyzer = require('efmls-configs.linters.dartanalyzer')
+```
+
+#### Formatters
+
+`dartfmt` [https://github.com/dart-lang/sdk/tree/master/utils/dartfmt](https://github.com/dart-lang/sdk/tree/master/utils/dartfmt)
+
+```lua
+local dartfmt = require('efmls-configs.formatters.dartfmt')
+```
+
+### Ruby
+
+#### Linters
+
+`debride` [https://github.com/seattlerb/debride](https://github.com/seattlerb/debride)
+
+```lua
+local debride = require('efmls-configs.linters.debride')
+```
+
+`reek` [https://github.com/troessner/reek](https://github.com/troessner/reek)
+
+```lua
+local reek = require('efmls-configs.linters.reek')
+```
+
+`rubocop` [https://github.com/bbatsov/rubocop](https://github.com/bbatsov/rubocop)
+
+```lua
+local rubocop = require('efmls-configs.linters.rubocop')
+```
+
+`sorbet` [https://github.com/sorbet/sorbet](https://github.com/sorbet/sorbet)
+
+```lua
+local sorbet = require('efmls-configs.linters.sorbet')
+```
+
+### Python
+
+#### Linters
+
+`djlint` [https://djlint.com/](https://djlint.com/)
+
+```lua
+local djlint = require('efmls-configs.linters.djlint')
+```
+
+`flake8` [http://flake8.pycqa.org/en/latest/](http://flake8.pycqa.org/en/latest/)
+
+```lua
+local flake8 = require('efmls-configs.linters.flake8')
+```
+
+`pylint` [https://www.pylint.org/](https://www.pylint.org/)
+
+```lua
+local pylint = require('efmls-configs.linters.pylint')
+```
+
+`vulture` [https://github.com/jendrikseipp/vulture](https://github.com/jendrikseipp/vulture)
+
+```lua
+local vulture = require('efmls-configs.linters.vulture')
+```
+
+#### Formatters
+
+`autopep8` [https://github.com/hhatto/autopep8](https://github.com/hhatto/autopep8)
+
+```lua
+local autopep8 = require('efmls-configs.formatters.autopep8')
+```
+
+`black` [https://github.com/ambv/black](https://github.com/ambv/black)
+
+```lua
+local black = require('efmls-configs.formatters.black')
+```
+
+`yapf` [https://github.com/google/yapf](https://github.com/google/yapf)
+
+```lua
+local yapf = require('efmls-configs.formatters.yapf')
+```
+
+### Go
+
+#### Linters
+
+`djlint` [https://djlint.com/](https://djlint.com/)
+
+```lua
+local djlint = require('efmls-configs.linters.djlint')
+```
+
+`go_revive` [https://github.com/mgechev/revive](https://github.com/mgechev/revive)
+
+```lua
+local go_revive = require('efmls-configs.linters.go_revive')
+```
+
+`golangci_lint` [https://github.com/golangci/golangci-lint](https://github.com/golangci/golangci-lint)
+
+```lua
+local golangci_lint = require('efmls-configs.linters.golangci_lint')
+```
+
+`golint` [https://godoc.org/github.com/golang/lint](https://godoc.org/github.com/golang/lint)
+
+```lua
+local golint = require('efmls-configs.linters.golint')
+```
+
+`staticcheck` [https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck)
+
+```lua
+local staticcheck = require('efmls-configs.linters.staticcheck')
+```
+
+#### Formatters
+
+`gofmt` [https://pkg.go.dev/cmd/gofmt](https://pkg.go.dev/cmd/gofmt)
+
+```lua
+local gofmt = require('efmls-configs.formatters.gofmt')
+```
+
+`goimports` [https://godoc.org/golang.org/x/tools/cmd/goimports](https://godoc.org/golang.org/x/tools/cmd/goimports)
+
+```lua
+local goimports = require('efmls-configs.formatters.goimports')
+```
+
+`golines` [https://github.com/segmentio/golines](https://github.com/segmentio/golines)
+
+```lua
+local golines = require('efmls-configs.formatters.golines')
+```
+
+### Php
+
+#### Linters
+
+`djlint` [https://djlint.com/](https://djlint.com/)
+
+```lua
+local djlint = require('efmls-configs.linters.djlint')
+```
+
+`phan` [https://github.com/phan/phan](https://github.com/phan/phan)
+
+```lua
+local phan = require('efmls-configs.linters.phan')
+```
+
+`php` [https://secure.php.net/](https://secure.php.net/)
+
+```lua
+local php = require('efmls-configs.linters.php')
+```
+
+`phpcs` [https://github.com/squizlabs/PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer)
+
+```lua
+local phpcs = require('efmls-configs.linters.phpcs')
+```
+
+`phpstan` [https://github.com/phpstan/phpstan](https://github.com/phpstan/phpstan)
+
+```lua
+local phpstan = require('efmls-configs.linters.phpstan')
+```
+
+`psalm` [https://getpsalm.org](https://getpsalm.org)
+
+```lua
+local psalm = require('efmls-configs.linters.psalm')
+```
+
+#### Formatters
+
+`php_cs_fixer` [https://github.com/PHP-CS-Fixer/PHP-CS-Fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer)
+
+```lua
+local php_cs_fixer = require('efmls-configs.formatters.php_cs_fixer')
+```
+
+`phpcbf` [https://github.com/squizlabs/PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer)
+
+```lua
+local phpcbf = require('efmls-configs.formatters.phpcbf')
+```
+
+`pint` [https://github.com/laravel/pint](https://github.com/laravel/pint)
+
+```lua
+local pint = require('efmls-configs.formatters.pint')
+```
+
+### Html
+
+#### Linters
+
+`djlint` [https://djlint.com/](https://djlint.com/)
+
+```lua
+local djlint = require('efmls-configs.linters.djlint')
+```
+
+#### Formatters
+
+`fecs` [http://fecs.baidu.com/](http://fecs.baidu.com/)
+
+```lua
+local fecs = require('efmls-configs.formatters.fecs')
+```
+
+`prettier` [https://github.com/prettier/prettier](https://github.com/prettier/prettier)
+
+```lua
+local prettier = require('efmls-configs.formatters.prettier')
+```
+
+`prettier_d` [https://github.com/fsouza/prettierd](https://github.com/fsouza/prettierd)
+
+```lua
+local prettier_d = require('efmls-configs.formatters.prettier_d')
+```
+
+### D
+
+#### Linters
+
+`dmd` [https://dlang.org/dmd-linux.html](https://dlang.org/dmd-linux.html)
+
+```lua
+local dmd = require('efmls-configs.linters.dmd')
+```
+
+#### Formatters
+
+`dfmt` [https://github.com/dlang-community/dfmt](https://github.com/dlang-community/dfmt)
+
+```lua
+local dfmt = require('efmls-configs.formatters.dfmt')
+```
+
+`uncrustify` [https://github.com/uncrustify/uncrustify](https://github.com/uncrustify/uncrustify)
+
+```lua
+local uncrustify = require('efmls-configs.formatters.uncrustify')
+```
+
 ### Javascript
 
 #### Linters
@@ -289,243 +637,47 @@ local prettier_standard = require('efmls-configs.formatters.prettier_standard')
 local xo = require('efmls-configs.formatters.xo')
 ```
 
-### Go
+### Typescript
 
 #### Linters
 
-`djlint` [https://djlint.com/](https://djlint.com/)
+`eslint` [http://eslint.org/](http://eslint.org/)
 
 ```lua
-local djlint = require('efmls-configs.linters.djlint')
+local eslint = require('efmls-configs.linters.eslint')
 ```
 
-`go_revive` [https://github.com/mgechev/revive](https://github.com/mgechev/revive)
+`eslint_d` [https://github.com/mantoni/eslint_d.js](https://github.com/mantoni/eslint_d.js)
 
 ```lua
-local go_revive = require('efmls-configs.linters.go_revive')
+local eslint_d = require('efmls-configs.linters.eslint_d')
 ```
 
-`golangci_lint` [https://github.com/golangci/golangci-lint](https://github.com/golangci/golangci-lint)
+`xo` [https://github.com/sindresorhus/xo](https://github.com/sindresorhus/xo)
 
 ```lua
-local golangci_lint = require('efmls-configs.linters.golangci_lint')
-```
-
-`golint` [https://godoc.org/github.com/golang/lint](https://godoc.org/github.com/golang/lint)
-
-```lua
-local golint = require('efmls-configs.linters.golint')
-```
-
-`staticcheck` [https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck)
-
-```lua
-local staticcheck = require('efmls-configs.linters.staticcheck')
+local xo = require('efmls-configs.linters.xo')
 ```
 
 #### Formatters
 
-`gofmt` [https://pkg.go.dev/cmd/gofmt](https://pkg.go.dev/cmd/gofmt)
+`dprint` [https://dprint.dev/](https://dprint.dev/)
 
 ```lua
-local gofmt = require('efmls-configs.formatters.gofmt')
+local dprint = require('efmls-configs.formatters.dprint')
 ```
 
-`goimports` [https://godoc.org/golang.org/x/tools/cmd/goimports](https://godoc.org/golang.org/x/tools/cmd/goimports)
+`eslint` [https://eslint.org](https://eslint.org)
 
 ```lua
-local goimports = require('efmls-configs.formatters.goimports')
+local eslint = require('efmls-configs.formatters.eslint')
 ```
 
-`golines` [https://github.com/segmentio/golines](https://github.com/segmentio/golines)
+`eslint_d` [https://github.com/mantoni/eslint_d.js](https://github.com/mantoni/eslint_d.js)
 
 ```lua
-local golines = require('efmls-configs.formatters.golines')
+local eslint_d = require('efmls-configs.formatters.eslint_d')
 ```
-
-### Sh
-
-#### Linters
-
-`shellcheck` [https://www.shellcheck.net/](https://www.shellcheck.net/)
-
-```lua
-local shellcheck = require('efmls-configs.linters.shellcheck')
-```
-
-#### Formatters
-
-`shfmt` [https://github.com/mvdan/sh](https://github.com/mvdan/sh)
-
-```lua
-local shfmt = require('efmls-configs.formatters.shfmt')
-```
-
-### Bash
-
-#### Linters
-
-`bashate` [https://github.com/openstack/bashate](https://github.com/openstack/bashate)
-
-```lua
-local bashate = require('efmls-configs.linters.bashate')
-```
-
-`shellcheck` [https://www.shellcheck.net/](https://www.shellcheck.net/)
-
-```lua
-local shellcheck = require('efmls-configs.linters.shellcheck')
-```
-
-#### Formatters
-
-`shfmt` [https://github.com/mvdan/sh](https://github.com/mvdan/sh)
-
-```lua
-local shfmt = require('efmls-configs.formatters.shfmt')
-```
-
-### Python
-
-#### Linters
-
-`djlint` [https://djlint.com/](https://djlint.com/)
-
-```lua
-local djlint = require('efmls-configs.linters.djlint')
-```
-
-`flake8` [http://flake8.pycqa.org/en/latest/](http://flake8.pycqa.org/en/latest/)
-
-```lua
-local flake8 = require('efmls-configs.linters.flake8')
-```
-
-`pylint` [https://www.pylint.org/](https://www.pylint.org/)
-
-```lua
-local pylint = require('efmls-configs.linters.pylint')
-```
-
-`vulture` [https://github.com/jendrikseipp/vulture](https://github.com/jendrikseipp/vulture)
-
-```lua
-local vulture = require('efmls-configs.linters.vulture')
-```
-
-#### Formatters
-
-`autopep8` [https://github.com/hhatto/autopep8](https://github.com/hhatto/autopep8)
-
-```lua
-local autopep8 = require('efmls-configs.formatters.autopep8')
-```
-
-`black` [https://github.com/ambv/black](https://github.com/ambv/black)
-
-```lua
-local black = require('efmls-configs.formatters.black')
-```
-
-`yapf` [https://github.com/google/yapf](https://github.com/google/yapf)
-
-```lua
-local yapf = require('efmls-configs.formatters.yapf')
-```
-
-### Yaml
-
-#### Linters
-
-`actionlint` [https://github.com/rhysd/actionlint](https://github.com/rhysd/actionlint)
-
-```lua
-local actionlint = require('efmls-configs.linters.actionlint')
-```
-
-`ansible_lint` [https://github.com/willthames/ansible-lint](https://github.com/willthames/ansible-lint)
-
-```lua
-local ansible_lint = require('efmls-configs.linters.ansible_lint')
-```
-
-`yamllint` [https://yamllint.readthedocs.io/](https://yamllint.readthedocs.io/)
-
-```lua
-local yamllint = require('efmls-configs.linters.yamllint')
-```
-
-### Php
-
-#### Linters
-
-`djlint` [https://djlint.com/](https://djlint.com/)
-
-```lua
-local djlint = require('efmls-configs.linters.djlint')
-```
-
-`phan` [https://github.com/phan/phan](https://github.com/phan/phan)
-
-```lua
-local phan = require('efmls-configs.linters.phan')
-```
-
-`php` [https://secure.php.net/](https://secure.php.net/)
-
-```lua
-local php = require('efmls-configs.linters.php')
-```
-
-`phpcs` [https://github.com/squizlabs/PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer)
-
-```lua
-local phpcs = require('efmls-configs.linters.phpcs')
-```
-
-`phpstan` [https://github.com/phpstan/phpstan](https://github.com/phpstan/phpstan)
-
-```lua
-local phpstan = require('efmls-configs.linters.phpstan')
-```
-
-`psalm` [https://getpsalm.org](https://getpsalm.org)
-
-```lua
-local psalm = require('efmls-configs.linters.psalm')
-```
-
-#### Formatters
-
-`php_cs_fixer` [https://github.com/PHP-CS-Fixer/PHP-CS-Fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer)
-
-```lua
-local php_cs_fixer = require('efmls-configs.formatters.php_cs_fixer')
-```
-
-`phpcbf` [https://github.com/squizlabs/PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer)
-
-```lua
-local phpcbf = require('efmls-configs.formatters.phpcbf')
-```
-
-`pint` [https://github.com/laravel/pint](https://github.com/laravel/pint)
-
-```lua
-local pint = require('efmls-configs.formatters.pint')
-```
-
-### Html
-
-#### Linters
-
-`djlint` [https://djlint.com/](https://djlint.com/)
-
-```lua
-local djlint = require('efmls-configs.linters.djlint')
-```
-
-#### Formatters
 
 `fecs` [http://fecs.baidu.com/](http://fecs.baidu.com/)
 
@@ -545,32 +697,50 @@ local prettier = require('efmls-configs.formatters.prettier')
 local prettier_d = require('efmls-configs.formatters.prettier_d')
 ```
 
-### Ruby
+`prettier_eslint` [https://github.com/prettier/prettier-eslint](https://github.com/prettier/prettier-eslint)
+
+```lua
+local prettier_eslint = require('efmls-configs.formatters.prettier_eslint')
+```
+
+`prettier_standard` [https://github.com/sheerun/prettier-standard](https://github.com/sheerun/prettier-standard)
+
+```lua
+local prettier_standard = require('efmls-configs.formatters.prettier_standard')
+```
+
+`xo` [https://github.com/sindresorhus/xo](https://github.com/sindresorhus/xo)
+
+```lua
+local xo = require('efmls-configs.formatters.xo')
+```
+
+### Fish
 
 #### Linters
 
-`debride` [https://github.com/seattlerb/debride](https://github.com/seattlerb/debride)
+`fish` [https://linux.die.net/man/1/fish](https://linux.die.net/man/1/fish)
 
 ```lua
-local debride = require('efmls-configs.linters.debride')
+local fish = require('efmls-configs.linters.fish')
 ```
 
-`reek` [https://github.com/troessner/reek](https://github.com/troessner/reek)
+#### Formatters
+
+`fish_indent` [https://fishshell.com/docs/current/cmds/fish_indent.html](https://fishshell.com/docs/current/cmds/fish_indent.html)
 
 ```lua
-local reek = require('efmls-configs.linters.reek')
+local fish_indent = require('efmls-configs.formatters.fish_indent')
 ```
 
-`rubocop` [https://github.com/bbatsov/rubocop](https://github.com/bbatsov/rubocop)
+### Docker
+
+#### Linters
+
+`hadolint` [https://github.com/hadolint/hadolint](https://github.com/hadolint/hadolint)
 
 ```lua
-local rubocop = require('efmls-configs.linters.rubocop')
-```
-
-`sorbet` [https://github.com/sorbet/sorbet](https://github.com/sorbet/sorbet)
-
-```lua
-local sorbet = require('efmls-configs.linters.sorbet')
+local hadolint = require('efmls-configs.linters.hadolint')
 ```
 
 ### Lua
@@ -597,64 +767,6 @@ local lua_format = require('efmls-configs.formatters.lua_format')
 local stylua = require('efmls-configs.formatters.stylua')
 ```
 
-### Solidity
-
-#### Linters
-
-`slither` [https://github.com/crytic/slither](https://github.com/crytic/slither)
-
-```lua
-local slither = require('efmls-configs.linters.slither')
-```
-
-`solhint` [https://github.com/protofire/solhint](https://github.com/protofire/solhint)
-
-```lua
-local solhint = require('efmls-configs.linters.solhint')
-```
-
-#### Formatters
-
-`forge_fmt` [https://github.com/foundry-rs/foundry/tree/master/forge](https://github.com/foundry-rs/foundry/tree/master/forge)
-
-```lua
-local forge_fmt = require('efmls-configs.formatters.forge_fmt')
-```
-
-### Crystal
-
-#### Linters
-
-`ameba` [https://github.com/veelenga/ameba](https://github.com/veelenga/ameba)
-
-```lua
-local ameba = require('efmls-configs.linters.ameba')
-```
-
-### Clojure
-
-#### Linters
-
-`clj_kondo` [https://github.com/borkdude/clj-kondo](https://github.com/borkdude/clj-kondo)
-
-```lua
-local clj_kondo = require('efmls-configs.linters.clj_kondo')
-```
-
-`joker` [https://github.com/candid82/joker](https://github.com/candid82/joker)
-
-```lua
-local joker = require('efmls-configs.linters.joker')
-```
-
-#### Formatters
-
-`joker` [https://github.com/candid82/joker](https://github.com/candid82/joker)
-
-```lua
-local joker = require('efmls-configs.formatters.joker')
-```
-
 ### C#
 
 #### Linters
@@ -679,22 +791,70 @@ local dotnet_format = require('efmls-configs.formatters.dotnet_format')
 local uncrustify = require('efmls-configs.formatters.uncrustify')
 ```
 
-### Dart
+### Sh
 
 #### Linters
 
-`dartanalyzer` [https://github.com/dart-lang/sdk/tree/master/pkg/analyzer_cli](https://github.com/dart-lang/sdk/tree/master/pkg/analyzer_cli)
+`shellcheck` [https://www.shellcheck.net/](https://www.shellcheck.net/)
 
 ```lua
-local dartanalyzer = require('efmls-configs.linters.dartanalyzer')
+local shellcheck = require('efmls-configs.linters.shellcheck')
 ```
 
 #### Formatters
 
-`dartfmt` [https://github.com/dart-lang/sdk/tree/master/utils/dartfmt](https://github.com/dart-lang/sdk/tree/master/utils/dartfmt)
+`beautysh` [https://github.com/illvart/beautysh-action](https://github.com/illvart/beautysh-action)
 
 ```lua
-local dartfmt = require('efmls-configs.formatters.dartfmt')
+local beautysh = require('efmls-configs.formatters.beautysh')
+```
+
+`shfmt` [https://github.com/mvdan/sh](https://github.com/mvdan/sh)
+
+```lua
+local shfmt = require('efmls-configs.formatters.shfmt')
+```
+
+### Solidity
+
+#### Linters
+
+`slither` [https://github.com/crytic/slither](https://github.com/crytic/slither)
+
+```lua
+local slither = require('efmls-configs.linters.slither')
+```
+
+`solhint` [https://github.com/protofire/solhint](https://github.com/protofire/solhint)
+
+```lua
+local solhint = require('efmls-configs.linters.solhint')
+```
+
+#### Formatters
+
+`forge_fmt` [https://github.com/foundry-rs/foundry/tree/master/forge](https://github.com/foundry-rs/foundry/tree/master/forge)
+
+```lua
+local forge_fmt = require('efmls-configs.formatters.forge_fmt')
+```
+
+### Nix
+
+#### Linters
+
+`statix` [https://github.com/NerdyPepper/statix](https://github.com/NerdyPepper/statix)
+
+```lua
+local statix = require('efmls-configs.linters.statix')
+```
+
+#### Formatters
+
+`nixfmt` [https://github.com/serokell/nixfmt](https://github.com/serokell/nixfmt)
+
+```lua
+local nixfmt = require('efmls-configs.formatters.nixfmt')
 ```
 
 ### Css
@@ -809,53 +969,15 @@ local prettier_d = require('efmls-configs.formatters.prettier_d')
 local vint = require('efmls-configs.linters.vint')
 ```
 
-### D
-
-#### Linters
-
-`dmd` [https://dlang.org/dmd-linux.html](https://dlang.org/dmd-linux.html)
-
-```lua
-local dmd = require('efmls-configs.linters.dmd')
-```
+### Markdown
 
 #### Formatters
 
-`dfmt` [https://github.com/dlang-community/dfmt](https://github.com/dlang-community/dfmt)
+`cbfmt` [https://github.com/lukas-reineke/cbfmt](https://github.com/lukas-reineke/cbfmt)
 
 ```lua
-local dfmt = require('efmls-configs.formatters.dfmt')
+local cbfmt = require('efmls-configs.formatters.cbfmt')
 ```
-
-`uncrustify` [https://github.com/uncrustify/uncrustify](https://github.com/uncrustify/uncrustify)
-
-```lua
-local uncrustify = require('efmls-configs.formatters.uncrustify')
-```
-
-### Typescript
-
-#### Linters
-
-`eslint` [http://eslint.org/](http://eslint.org/)
-
-```lua
-local eslint = require('efmls-configs.linters.eslint')
-```
-
-`eslint_d` [https://github.com/mantoni/eslint_d.js](https://github.com/mantoni/eslint_d.js)
-
-```lua
-local eslint_d = require('efmls-configs.linters.eslint_d')
-```
-
-`xo` [https://github.com/sindresorhus/xo](https://github.com/sindresorhus/xo)
-
-```lua
-local xo = require('efmls-configs.linters.xo')
-```
-
-#### Formatters
 
 `dprint` [https://dprint.dev/](https://dprint.dev/)
 
@@ -863,22 +985,14 @@ local xo = require('efmls-configs.linters.xo')
 local dprint = require('efmls-configs.formatters.dprint')
 ```
 
-`eslint` [https://eslint.org](https://eslint.org)
+### Json
+
+#### Formatters
+
+`dprint` [https://dprint.dev/](https://dprint.dev/)
 
 ```lua
-local eslint = require('efmls-configs.formatters.eslint')
-```
-
-`eslint_d` [https://github.com/mantoni/eslint_d.js](https://github.com/mantoni/eslint_d.js)
-
-```lua
-local eslint_d = require('efmls-configs.formatters.eslint_d')
-```
-
-`fecs` [http://fecs.baidu.com/](http://fecs.baidu.com/)
-
-```lua
-local fecs = require('efmls-configs.formatters.fecs')
+local dprint = require('efmls-configs.formatters.dprint')
 ```
 
 `prettier` [https://github.com/prettier/prettier](https://github.com/prettier/prettier)
@@ -893,68 +1007,60 @@ local prettier = require('efmls-configs.formatters.prettier')
 local prettier_d = require('efmls-configs.formatters.prettier_d')
 ```
 
-`prettier_eslint` [https://github.com/prettier/prettier-eslint](https://github.com/prettier/prettier-eslint)
-
-```lua
-local prettier_eslint = require('efmls-configs.formatters.prettier_eslint')
-```
-
-`prettier_standard` [https://github.com/sheerun/prettier-standard](https://github.com/sheerun/prettier-standard)
-
-```lua
-local prettier_standard = require('efmls-configs.formatters.prettier_standard')
-```
-
-`xo` [https://github.com/sindresorhus/xo](https://github.com/sindresorhus/xo)
-
-```lua
-local xo = require('efmls-configs.formatters.xo')
-```
-
-### Docker
-
-#### Linters
-
-`hadolint` [https://github.com/hadolint/hadolint](https://github.com/hadolint/hadolint)
-
-```lua
-local hadolint = require('efmls-configs.linters.hadolint')
-```
-
-### Fish
-
-#### Linters
-
-`fish` [https://linux.die.net/man/1/fish](https://linux.die.net/man/1/fish)
-
-```lua
-local fish = require('efmls-configs.linters.fish')
-```
+### Toml
 
 #### Formatters
 
-`fish_indent` [https://fishshell.com/docs/current/cmds/fish_indent.html](https://fishshell.com/docs/current/cmds/fish_indent.html)
+`dprint` [https://dprint.dev/](https://dprint.dev/)
 
 ```lua
-local fish_indent = require('efmls-configs.formatters.fish_indent')
+local dprint = require('efmls-configs.formatters.dprint')
 ```
 
-### Nix
-
-#### Linters
-
-`statix` [https://github.com/NerdyPepper/statix](https://github.com/NerdyPepper/statix)
-
-```lua
-local statix = require('efmls-configs.linters.statix')
-```
+### Rust
 
 #### Formatters
 
-`nixfmt` [https://github.com/serokell/nixfmt](https://github.com/serokell/nixfmt)
+`dprint` [https://dprint.dev/](https://dprint.dev/)
 
 ```lua
-local nixfmt = require('efmls-configs.formatters.nixfmt')
+local dprint = require('efmls-configs.formatters.dprint')
+```
+
+`rustfmt` [https://github.com/rust-lang-nursery/rustfmt](https://github.com/rust-lang-nursery/rustfmt)
+
+```lua
+local rustfmt = require('efmls-configs.formatters.rustfmt')
+```
+
+### Roslyn
+
+#### Formatters
+
+`dprint` [https://dprint.dev/](https://dprint.dev/)
+
+```lua
+local dprint = require('efmls-configs.formatters.dprint')
+```
+
+### Sml
+
+#### Formatters
+
+`smlfmt` [https://github.com/shwestrick/smlfmt](https://github.com/shwestrick/smlfmt)
+
+```lua
+local smlfmt = require('efmls-configs.formatters.smlfmt')
+```
+
+### Terraform
+
+#### Formatters
+
+`terraform_fmt` [https://github.com/hashicorp/terraform](https://github.com/hashicorp/terraform)
+
+```lua
+local terraform_fmt = require('efmls-configs.formatters.terraform_fmt')
 ```
 
 ### Java
@@ -1007,97 +1113,53 @@ local uncrustify = require('efmls-configs.formatters.uncrustify')
 local uncrustify = require('efmls-configs.formatters.uncrustify')
 ```
 
-### Json
+### Zsh
 
 #### Formatters
 
-`dprint` [https://dprint.dev/](https://dprint.dev/)
+`beautysh` [https://github.com/illvart/beautysh-action](https://github.com/illvart/beautysh-action)
 
 ```lua
-local dprint = require('efmls-configs.formatters.dprint')
+local beautysh = require('efmls-configs.formatters.beautysh')
 ```
 
-`prettier` [https://github.com/prettier/prettier](https://github.com/prettier/prettier)
-
-```lua
-local prettier = require('efmls-configs.formatters.prettier')
-```
-
-`prettier_d` [https://github.com/fsouza/prettierd](https://github.com/fsouza/prettierd)
-
-```lua
-local prettier_d = require('efmls-configs.formatters.prettier_d')
-```
-
-### Markdown
+### Csh
 
 #### Formatters
 
-`cbfmt` [https://github.com/lukas-reineke/cbfmt](https://github.com/lukas-reineke/cbfmt)
+`beautysh` [https://github.com/illvart/beautysh-action](https://github.com/illvart/beautysh-action)
 
 ```lua
-local cbfmt = require('efmls-configs.formatters.cbfmt')
+local beautysh = require('efmls-configs.formatters.beautysh')
 ```
 
-`dprint` [https://dprint.dev/](https://dprint.dev/)
-
-```lua
-local dprint = require('efmls-configs.formatters.dprint')
-```
-
-### Sml
+### Ksh
 
 #### Formatters
 
-`smlfmt` [https://github.com/shwestrick/smlfmt](https://github.com/shwestrick/smlfmt)
+`beautysh` [https://github.com/illvart/beautysh-action](https://github.com/illvart/beautysh-action)
 
 ```lua
-local smlfmt = require('efmls-configs.formatters.smlfmt')
+local beautysh = require('efmls-configs.formatters.beautysh')
 ```
 
-### Terraform
+### Haskell
 
 #### Formatters
 
-`terraform_fmt` [https://github.com/hashicorp/terraform](https://github.com/hashicorp/terraform)
+`fourmolu` [https://github.com/fourmolu/fourmolu](https://github.com/fourmolu/fourmolu)
 
 ```lua
-local terraform_fmt = require('efmls-configs.formatters.terraform_fmt')
+local fourmolu = require('efmls-configs.formatters.fourmolu')
 ```
 
-### Rust
+### Cmake
 
 #### Formatters
 
-`dprint` [https://dprint.dev/](https://dprint.dev/)
+`gersemi` [https://github.com/BlankSpruce/gersemi](https://github.com/BlankSpruce/gersemi)
 
 ```lua
-local dprint = require('efmls-configs.formatters.dprint')
-```
-
-`rustfmt` [https://github.com/rust-lang-nursery/rustfmt](https://github.com/rust-lang-nursery/rustfmt)
-
-```lua
-local rustfmt = require('efmls-configs.formatters.rustfmt')
-```
-
-### Toml
-
-#### Formatters
-
-`dprint` [https://dprint.dev/](https://dprint.dev/)
-
-```lua
-local dprint = require('efmls-configs.formatters.dprint')
-```
-
-### Roslyn
-
-#### Formatters
-
-`dprint` [https://dprint.dev/](https://dprint.dev/)
-
-```lua
-local dprint = require('efmls-configs.formatters.dprint')
+local gersemi = require('efmls-configs.formatters.gersemi')
 ```
 

--- a/lua/efmls-configs/formatters/beautysh.lua
+++ b/lua/efmls-configs/formatters/beautysh.lua
@@ -1,0 +1,14 @@
+-- Metadata
+-- languages: sh, bash, zsh, csh, ksh
+-- url: https://github.com/illvart/beautysh-action
+
+local fs = require('efmls-configs.fs')
+
+local formatter = 'beautysh'
+local command = string.format('%s -', fs.executable(formatter))
+
+return {
+  prefix = formatter,
+  formatCommand = command,
+  formatStdin = true,
+}

--- a/lua/efmls-configs/formatters/fourmolu.lua
+++ b/lua/efmls-configs/formatters/fourmolu.lua
@@ -1,0 +1,14 @@
+-- Metadata
+-- languages: haskell
+-- url: https://github.com/fourmolu/fourmolu
+
+local fs = require('efmls-configs.fs')
+
+local formatter = 'fourmolu'
+local command = string.format('%s --stdin-input-file ${INPUT} -', fs.executable(formatter))
+
+return {
+  prefix = formatter,
+  formatCommand = command,
+  formatStdin = true,
+}

--- a/lua/efmls-configs/formatters/gersemi.lua
+++ b/lua/efmls-configs/formatters/gersemi.lua
@@ -1,0 +1,14 @@
+-- Metadata
+-- languages: cmake
+-- url: https://github.com/BlankSpruce/gersemi
+
+local fs = require('efmls-configs.fs')
+
+local formatter = 'gersemi'
+local command = string.format('%s -', fs.executable(formatter))
+
+return {
+  prefix = 'gersemi',
+  formatCommand = command,
+  formatStdin = true,
+}

--- a/lua/efmls-configs/formatters/gersemi.lua
+++ b/lua/efmls-configs/formatters/gersemi.lua
@@ -8,7 +8,7 @@ local formatter = 'gersemi'
 local command = string.format('%s -', fs.executable(formatter))
 
 return {
-  prefix = 'gersemi',
+  prefix = formatter,
   formatCommand = command,
   formatStdin = true,
 }

--- a/lua/efmls-configs/linters/cppcheck.lua
+++ b/lua/efmls-configs/linters/cppcheck.lua
@@ -5,12 +5,15 @@
 local fs = require('efmls-configs.fs')
 
 local linter = 'cppcheck'
-local command = string.format('%s --enable=warning ${INPUT}', fs.executable(linter))
+local command = string.format(
+  '%s --quiet --force --enable=warning,style,performance,portability --error-exitcode=1  ${INPUT}',
+  fs.executable(linter)
+)
 
 return {
   prefix = linter,
   lintCommand = command,
   lintStdin = false,
-  lintFormats = { '%.%#:%l:%c: %trror: %m', '%.%#:%l:%c: %tarning: %m', '%.%#:%l:%c: %tote: %m' },
-  rootMarkers = {},
+  lintFormats = { '%f:%l:%c: %trror: %m', '%f:%l:%c: %tarning: %m', '%f:%l:%c: %tote: %m' },
+  rootMarkers = { 'CmakeLists.txt', 'compile_commands.json', '.git' },
 }

--- a/lua/efmls-configs/linters/cppcheck.lua
+++ b/lua/efmls-configs/linters/cppcheck.lua
@@ -5,15 +5,12 @@
 local fs = require('efmls-configs.fs')
 
 local linter = 'cppcheck'
-local command = string.format(
-  '%s --quiet --force --enable=warning,style,performance,portability --error-exitcode=1  ${INPUT}',
-  fs.executable(linter)
-)
+local command = string.format('%s --enable=warning ${INPUT}', fs.executable(linter))
 
 return {
   prefix = linter,
   lintCommand = command,
   lintStdin = false,
-  lintFormats = { '%f:%l:%c: %trror: %m', '%f:%l:%c: %tarning: %m', '%f:%l:%c: %tote: %m' },
-  rootMarkers = { 'CmakeLists.txt', 'compile_commands.json', '.git' },
+  lintFormats = { '%.%#:%l:%c: %trror: %m', '%.%#:%l:%c: %tarning: %m', '%.%#:%l:%c: %tote: %m' },
+  rootMarkers = {},
 }


### PR DESCRIPTION
This pull request adds the fourmolu, gersemi, and beautysh formattrs to the repository. It also fixes the lintCommand of the cppcheck linter, since i could not get it to work . Moreover, i added rootMarkers for cppcheck and i changed the command into a more mainstream one.

I believe these changes will be useful, especially since the archiving of null-ls

Thank you for your time and effort and considering this pull request.