### PR TITLE
Update shellcheck.lua

### DIFF
--- a/lua/efmls-configs/linters/shellcheck.lua
+++ b/lua/efmls-configs/linters/shellcheck.lua
@@ -10,7 +10,8 @@ local command = string.format('%s --color=never --format=gcc -', fs.executable(l
 return {
   prefix = linter,
   lintCommand = command,
+  lintSource = "shellcheck",
   lintStdin = true,
   lintFormats = { '-:%l:%c: %trror: %m', '-:%l:%c: %tarning: %m', '-:%l:%c: %tote: %m' },
-  rootMarkers = {},
+  rootMarkers = { ".shellcheckrc" },
 }


### PR DESCRIPTION
lintSource is used as the `diagnositc.source` in the diagnostic float format callback for `vim.diagnostic.config` also documented in the readme example at https://github.com/mattn/efm-langserver

`.shellcheckrc` is an optional rootMarker (hence no `requireMarker`) https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md#rc-files