### PR TITLE
Fix cppcheck lintFormats add rootMarkers change lintCommand

### DIFF
--- a/lua/efmls-configs/linters/cppcheck.lua
+++ b/lua/efmls-configs/linters/cppcheck.lua
@@ -5,12 +5,15 @@
 local fs = require('efmls-configs.fs')
 
 local linter = 'cppcheck'
-local command = string.format('%s --enable=warning ${INPUT}', fs.executable(linter))
+local command = string.format(
+  '%s --quiet --force --enable=warning,style,performance,portability --error-exitcode=1  ${INPUT}',
+  fs.executable(linter)
+)
 
 return {
   prefix = linter,
   lintCommand = command,
   lintStdin = false,
-  lintFormats = { '%.%#:%l:%c: %trror: %m', '%.%#:%l:%c: %tarning: %m', '%.%#:%l:%c: %tote: %m' },
-  rootMarkers = {},
+  lintFormats = { '%f:%l:%c: %trror: %m', '%f:%l:%c: %tarning: %m', '%f:%l:%c: %tote: %m' },
+  rootMarkers = { 'CmakeLists.txt', 'compile_commands.json', '.git' },
 }


### PR DESCRIPTION
I fixed the cppcheck linter, because i could not get it to work. I changed the format of the output, i added rootmarkers and changed the command into a more maistream one.

I believe the changes are going to be useful for the majority of users.

Thank you for your time and effort and considering this PR.
