### PR TITLE
feat(linters): ignore exit code for flake8

### DIFF
--- a/lua/efmls-configs/linters/flake8.lua
+++ b/lua/efmls-configs/linters/flake8.lua
@@ -10,6 +10,7 @@ local command = string.format('%s -', fs.executable(linter))
 return {
   prefix = linter,
   lintCommand = command,
+  lintIgnoreExitCode = true,
   lintStdin = true,
   lintFormats = { 'stdin:%l:%c: %t%n %m' },
   rootMarkers = { 'setup.cfg', 'tox.ini', '.flake8' },


### PR DESCRIPTION
LspLog currently shows this error message.

```
[ERROR][2023-08-26 15:07:04] ...lsp/handlers.lua:543	"command `<redacted>/bin/flake8 -` exit with zero. probably you forgot to specify `lint-ignore-exit-code: true`."
```

Let's  add `lintIgnoreExitCode = true` for `flake8` as it has been enabled for many other linters already.