### PR TITLE
fix(linters/codespell): lintSeverity starts from warn

### DIFF
--- a/lua/efmls-configs/linters/codespell.lua
+++ b/lua/efmls-configs/linters/codespell.lua
@@ -15,4 +15,6 @@ return {
   lintIgnoreExitCode = true,
   lintStdin = false,
   lintFormats = { '%f:%l:%m' },
+  -- Min severity should start from warning
+  lintSeverity = 2,
 }


### PR DESCRIPTION
@chrisgrieser referencing from this comment: https://github.com/creativenull/efmls-configs-nvim/pull/63#issuecomment-1699402368

I did not know there was a way to set a minimum severity level until I saw #67 

With this change we should see the spelling mistakes as warnings instead of errors.