### PR TITLE
add chktex linter

### DIFF
--- a/lua/efmls-configs/linters/chktex.lua
+++ b/lua/efmls-configs/linters/chktex.lua
@@ -1,0 +1,18 @@
+-- Metadata
+-- languages: tex
+-- url: https://www.nongnu.org/chktex/
+
+local fs = require('efmls-configs.fs')
+
+local linter = 'chktex'
+local command = string.format('%s -q -v0', fs.executable(linter))
+
+return {
+  prefix = linter,
+  lintSource = linter,
+  lintStdin = true,
+  lintCommand = command,
+  lintIgnoreExitCode = true,
+  lintFormats = { '%f:%l:%c:%n:%m' },
+  lintSeverity = 2,
+}


### PR DESCRIPTION
I added the chktex linter. The severity is correct, the warn code is parsed, the error code is ignored. I think that this linter is a pretty basic one to include, even though it can be used with the texlab LSP. Overall i think it is worth it.

Thank you for your effort including these PRs! :)