### PR TITLE
fix(formatters): Wrap filenames in single quotes

### DIFF
--- a/lua/efmls-configs/formatters/astyle.lua
+++ b/lua/efmls-configs/formatters/astyle.lua
@@ -5,7 +5,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'astyle'
-local command = string.format('%s --stdin=${INPUT}', fs.executable(formatter))
+local command = string.format("%s --stdin='${INPUT}'", fs.executable(formatter))
 
 return {
   formatCommand = command,

--- a/lua/efmls-configs/formatters/biome.lua
+++ b/lua/efmls-configs/formatters/biome.lua
@@ -5,7 +5,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'biome'
-local args = 'format --stdin-file-path ${INPUT}'
+local args = "format --stdin-file-path '${INPUT}'"
 local command = string.format('%s %s', fs.executable(formatter, fs.Scope.NODE), args)
 
 return {

--- a/lua/efmls-configs/formatters/blade_formatter.lua
+++ b/lua/efmls-configs/formatters/blade_formatter.lua
@@ -5,7 +5,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'blade-formatter'
-local command = string.format('%s ${INPUT}', fs.executable(formatter))
+local command = string.format("%s '${INPUT}'", fs.executable(formatter))
 
 return {
   formatCommand = command,

--- a/lua/efmls-configs/formatters/cbfmt.lua
+++ b/lua/efmls-configs/formatters/cbfmt.lua
@@ -4,7 +4,7 @@
 
 local fs = require('efmls-configs.fs')
 local formatter = fs.executable('cbfmt')
-local command = string.format('%s --stdin-filepath ${INPUT} --best-effort', formatter)
+local command = string.format("%s --stdin-filepath '${INPUT}' --best-effort", formatter)
 
 return {
   formatCommand = command,

--- a/lua/efmls-configs/formatters/clang_format.lua
+++ b/lua/efmls-configs/formatters/clang_format.lua
@@ -5,7 +5,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'clang-format'
-local command = string.format('%s ${INPUT}', fs.executable(formatter))
+local command = string.format("%s '${INPUT}'", fs.executable(formatter))
 
 return {
   formatCommand = command,

--- a/lua/efmls-configs/formatters/clang_tidy.lua
+++ b/lua/efmls-configs/formatters/clang_tidy.lua
@@ -5,7 +5,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'clang-tidy'
-local command = string.format('%s -fix ${INPUT}', fs.executable(formatter))
+local command = string.format("%s -fix '${INPUT}'", fs.executable(formatter))
 
 return {
   formatCommand = command,

--- a/lua/efmls-configs/formatters/dprint.lua
+++ b/lua/efmls-configs/formatters/dprint.lua
@@ -5,7 +5,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'dprint'
-local command = string.format('%s fmt --stdin ${INPUT}', fs.executable(formatter, fs.Scope.NODE))
+local command = string.format("%s fmt --stdin '${INPUT}'", fs.executable(formatter, fs.Scope.NODE))
 
 return {
   formatCommand = command,

--- a/lua/efmls-configs/formatters/eslint.lua
+++ b/lua/efmls-configs/formatters/eslint.lua
@@ -5,7 +5,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'eslint'
-local args = '--fix ${INPUT}'
+local args = "--fix '${INPUT}'"
 local command = string.format('%s %s', fs.executable(formatter, fs.Scope.NODE), args)
 
 return {

--- a/lua/efmls-configs/formatters/eslint_d.lua
+++ b/lua/efmls-configs/formatters/eslint_d.lua
@@ -5,7 +5,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'eslint_d'
-local args = '--fix-to-stdout --stdin-filename ${INPUT} --stdin'
+local args = "--fix-to-stdout --stdin-filename '${INPUT}' --stdin"
 local command = string.format('%s %s', fs.executable(formatter, fs.Scope.NODE), args)
 
 return {

--- a/lua/efmls-configs/formatters/fecs.lua
+++ b/lua/efmls-configs/formatters/fecs.lua
@@ -9,7 +9,7 @@ local fs = require('efmls-configs.fs')
 -- at the line. Check for workarounds, if possible.
 
 local formatter = 'fecs'
-local args = 'format --silent --ignore --stream ${INPUT}'
+local args = "format --silent --ignore --stream '${INPUT}'"
 local command = string.format('%s %s', fs.executable(formatter, fs.Scope.NODE), args)
 
 return {

--- a/lua/efmls-configs/formatters/fourmolu.lua
+++ b/lua/efmls-configs/formatters/fourmolu.lua
@@ -5,7 +5,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'fourmolu'
-local command = string.format('%s --stdin-input-file ${INPUT} -', fs.executable(formatter))
+local command = string.format("%s --stdin-input-file '${INPUT}' -", fs.executable(formatter))
 
 return {
   prefix = formatter,

--- a/lua/efmls-configs/formatters/joker.lua
+++ b/lua/efmls-configs/formatters/joker.lua
@@ -5,7 +5,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'joker'
-local command = string.format('%s --format ${INPUT}', fs.executable(formatter))
+local command = string.format("%s --format '${INPUT}'", fs.executable(formatter))
 
 return {
   formatCommand = command,

--- a/lua/efmls-configs/formatters/lua_format.lua
+++ b/lua/efmls-configs/formatters/lua_format.lua
@@ -5,7 +5,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'lua-format'
-local command = string.format('%s ${INPUT}', fs.executable(formatter))
+local command = string.format("%s '${INPUT}'", fs.executable(formatter))
 
 return {
   formatCommand = command,

--- a/lua/efmls-configs/formatters/perlimports.lua
+++ b/lua/efmls-configs/formatters/perlimports.lua
@@ -1,7 +1,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'perlimports'
-local args = '--read-stdin --filename ${INPUT}'
+local args = "--read-stdin --filename '${INPUT}'"
 local command = string.format('%s %s', fs.executable(formatter), args)
 
 return {

--- a/lua/efmls-configs/formatters/php_cs_fixer.lua
+++ b/lua/efmls-configs/formatters/php_cs_fixer.lua
@@ -5,7 +5,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'php-cs-fixer'
-local args = 'fix --no-ansi --using-cache=no --quiet ${INPUT}'
+local args = "fix --no-ansi --using-cache=no --quiet '${INPUT}'"
 local command = string.format('%s %s', fs.executable(formatter, fs.Scope.COMPOSER), args)
 
 return {

--- a/lua/efmls-configs/formatters/pint.lua
+++ b/lua/efmls-configs/formatters/pint.lua
@@ -5,7 +5,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'pint'
-local args = '${INPUT}'
+local args = "'${INPUT}'"
 local command = string.format('%s %s', fs.executable(formatter, fs.Scope.COMPOSER), args)
 
 return {

--- a/lua/efmls-configs/formatters/prettier.lua
+++ b/lua/efmls-configs/formatters/prettier.lua
@@ -6,7 +6,7 @@ local fs = require('efmls-configs.fs')
 
 local formatter = 'prettier'
 local command = string.format(
-  '%s --stdin --stdin-filepath ${INPUT} ${--range-start:charStart} '
+  "%s --stdin --stdin-filepath '${INPUT}' ${--range-start:charStart} "
     .. '${--range-end:charEnd} ${--tab-width:tabSize} ${--use-tabs:!insertSpaces}',
   fs.executable(formatter, fs.Scope.NODE)
 )

--- a/lua/efmls-configs/formatters/prettier_d.lua
+++ b/lua/efmls-configs/formatters/prettier_d.lua
@@ -6,7 +6,7 @@ local fs = require('efmls-configs.fs')
 
 local formatter = 'prettierd'
 local command = string.format(
-  '%s ${INPUT} ${--range-start=charStart} ${--range-end=charEnd} '
+  "%s '${INPUT}' ${--range-start=charStart} ${--range-end=charEnd} "
     .. '${--tab-width=tabSize} ${--use-tabs=!insertSpaces}',
   fs.executable(formatter, fs.Scope.NODE)
 )

--- a/lua/efmls-configs/formatters/prettier_eslint.lua
+++ b/lua/efmls-configs/formatters/prettier_eslint.lua
@@ -5,7 +5,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'prettier-eslint'
-local command = string.format('%s --stdin --stdin-filepath ${INPUT}', fs.executable(formatter, fs.Scope.NODE))
+local command = string.format("%s --stdin --stdin-filepath '${INPUT}'", fs.executable(formatter, fs.Scope.NODE))
 
 return {
   formatCommand = command,

--- a/lua/efmls-configs/formatters/rome.lua
+++ b/lua/efmls-configs/formatters/rome.lua
@@ -5,7 +5,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'rome'
-local args = 'format --stdin-file-path ${INPUT}'
+local args = "format --stdin-file-path '${INPUT}'"
 local command = string.format('%s %s', fs.executable(formatter, fs.Scope.NODE), args)
 
 return {

--- a/lua/efmls-configs/formatters/ruff.lua
+++ b/lua/efmls-configs/formatters/ruff.lua
@@ -5,7 +5,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'ruff'
-local args = 'check --fix-only --no-cache --stdin-filename ${INPUT}'
+local args = "check --fix-only --no-cache --stdin-filename '${INPUT}'"
 local command = string.format('%s %s', fs.executable(formatter), args)
 
 return {

--- a/lua/efmls-configs/formatters/shfmt.lua
+++ b/lua/efmls-configs/formatters/shfmt.lua
@@ -5,7 +5,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'shfmt'
-local command = string.format('%s -filename ${INPUT} -', fs.executable(formatter))
+local command = string.format("%s -filename '${INPUT}' -", fs.executable(formatter))
 
 return {
   formatCommand = command,

--- a/lua/efmls-configs/formatters/uncrustify.lua
+++ b/lua/efmls-configs/formatters/uncrustify.lua
@@ -5,7 +5,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'uncrustify'
-local command = string.format('%s -q ${INPUT}', fs.executable(formatter))
+local command = string.format("%s -q '${INPUT}'", fs.executable(formatter))
 
 return {
   formatCommand = command,


### PR DESCRIPTION
Currently formatting files with spaces in the filename doesn't work. With single quotes the filenames stay as as single argument instead of splitting.

I have only tested prettier, however I don't see any reason why the others wouldn't work. (As a note, the argument `smth='word    word'` is passed without quotes: `smth=word    word`) 