### PR TITLE
Add prettier for yaml

### DIFF
--- a/doc/SUPPORTED_LIST.md
+++ b/doc/SUPPORTED_LIST.md
@@ -1385,6 +1385,12 @@ local yamllint = require('efmls-configs.linters.yamllint')
 
 #### Formatters
 
+`prettier` [https://github.com/prettier/prettier](https://github.com/prettier/prettier)
+
+```lua
+local prettier = require('efmls-configs.formatters.prettier')
+```
+
 `yq` [https://github.com/mikefarah/yq](https://github.com/mikefarah/yq)
 
 ```lua

--- a/lua/efmls-configs/formatters/prettier.lua
+++ b/lua/efmls-configs/formatters/prettier.lua
@@ -1,5 +1,5 @@
 -- Metadata
--- languages: javascript,typescript,css,scss,sass,less,html,json
+-- languages: javascript,typescript,css,scss,sass,less,html,json,yaml
 -- url: https://github.com/prettier/prettier
 
 local fs = require('efmls-configs.fs')


### PR DESCRIPTION
prettier supports YAML formatting. Add appropriate metadata and
regenerate docs.
