### PR TITLE
Make rubocop configurable

### DIFF
--- a/lua/efmls-configs/linters/rubocop.lua
+++ b/lua/efmls-configs/linters/rubocop.lua
@@ -6,13 +6,28 @@ local sourceText = require('efmls-configs.utils').sourceText
 local fs = require('efmls-configs.fs')
 
 local linter = 'rubocop'
-local command = string.format('%s --lint --format emacs --stdin "${INPUT}"', fs.executable(linter, fs.Scope.BUNDLE))
 
-return {
+local function commandBuilder(args)
+  args = args or '--lint --format emacs --stdin "${INPUT}"'
+
+  return string.format('%s %s', fs.executable(linter, fs.Scope.BUNDLE), args)
+end
+
+local data = {
   prefix = linter,
   lintSource = sourceText(linter),
-  lintCommand = command,
+  lintCommand = commandBuilder(),
   lintStdin = true,
   lintFormats = { '%f:%l:%c: %t: %m' },
   rootMarkers = {},
 }
+
+return setmetatable(data, {
+  __call = function(t, opts)
+    if opts.args ~= nil then
+      t.lintCommand = commandBuilder(opts.args)
+    end
+
+    return vim.tbl_extend('force', t, opts.override or {})
+  end,
+})


### PR DESCRIPTION
I like the idea to have all the configurations on a central repository, but the problem with that is that some people might use some configurations differently. For instance, I personally think that `--lint` is a bit too restrictive.

I was using these configurations _manually_ on my neovim. But I think that having the power to configure these settings can be helpful for more people.

With the proposed code, one can do:

```lua
local languages = {
  -- ...

  ruby = {
    require('efmls-configs.linters.rubocop')({
      args = '--format emacs --stdin "${INPUT}"',
      override = {
        lintCategoryMap = {
          A = 'H', -- autocorrect
          C = 'I', -- convention
          E = 'E', -- error
          F = 'E', -- fatal
          I = 'I', -- info
          R = 'H', -- refactor
          W = 'W', -- warning
        },
      },
    }),
  },
  
  -- ...
}

```

What do you think?