### PR TITLE
Add sql-formatter config

### DIFF
--- a/lua/efmls-configs/formatters/sql-formatter.lua
+++ b/lua/efmls-configs/formatters/sql-formatter.lua
@@ -5,7 +5,6 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'sql-formatter'
-
 local command = string.format('%s', fs.executable(formatter, fs.Scope.NODE))
 
 return {

--- a/lua/efmls-configs/formatters/sql-formatter.lua
+++ b/lua/efmls-configs/formatters/sql-formatter.lua
@@ -3,19 +3,10 @@
 -- url: https://github.com/sql-formatter-org/sql-formatter
 
 local fs = require('efmls-configs.fs')
-local ok, Path = pcall(require, 'plenary.path')
-
-local args = ''
-if ok then
-  local cfg = Path:new(vim.fn.stdpath('config'), 'sql-formatter.json')
-  if cfg:exists() and cfg:is_file() then
-    args = string.format('--config %s', cfg)
-  end
-end
 
 local formatter = 'sql-formatter'
 
-local command = string.format('%s %s', fs.executable(formatter, fs.Scope.NODE), args)
+local command = string.format('%s', fs.executable(formatter, fs.Scope.NODE))
 
 return {
   formatCommand = command,

--- a/lua/efmls-configs/formatters/sql-formatter.lua
+++ b/lua/efmls-configs/formatters/sql-formatter.lua
@@ -1,0 +1,23 @@
+-- Metadata
+-- languages: sql
+-- url: https://github.com/sql-formatter-org/sql-formatter
+
+local fs = require('efmls-configs.fs')
+local ok, Path = pcall(require, 'plenary.path')
+
+local args = ''
+if ok then
+  local cfg = Path:new(vim.fn.stdpath('config'), 'sql-formatter.json')
+  if cfg:exists() and cfg:is_file() then
+    args = string.format('--config %s', cfg)
+  end
+end
+
+local formatter = 'sql-formatter'
+
+local command = string.format('%s %s', fs.executable(formatter, fs.Scope.NODE), args)
+
+return {
+  formatCommand = command,
+  formatStdin = true,
+}


### PR DESCRIPTION
Simple change to add support for sql-formatter. It also checks your neovim config folder for a sql-formatter config file (the options can be found on their GitHub page). 

A future change could add support to mark a json file as a rootMarker. The only thing is that there's no standard name for this file like `.editorconfig` or `.eslint` or something.