### PR TITLE
fix(health): bump min to 0.7, support new health api

### DIFF
--- a/lua/efmls-configs/health/init.lua
+++ b/lua/efmls-configs/health/init.lua
@@ -1,6 +1,6 @@
 local M = {}
 
----Report ok message to :checkhealth support only for nvim >= 0.8
+---Report ok message to :checkhealth support only for nvim >= 0.7
 ---@param msg string
 ---@return nil
 local function report_ok(msg)
@@ -8,10 +8,12 @@ local function report_ok(msg)
     vim.health.ok(msg)
   elseif vim.fn.has('nvim-0.8') == 1 then
     vim.health.report_ok(msg)
+  elseif vim.fn.has('nvim-0.7') == 1 then
+    require('health').report_ok(msg)
   end
 end
 
----Report error message to :checkhealth support only for nvim >= 0.8
+---Report error message to :checkhealth support only for nvim >= 0.7
 ---@param msg string
 ---@return nil
 local function report_error(msg)
@@ -19,6 +21,8 @@ local function report_error(msg)
     vim.health.error(msg)
   elseif vim.fn.has('nvim-0.8') == 1 then
     vim.health.report_error(msg)
+  elseif vim.fn.has('nvim-0.7') == 1 then
+    require('health').report_error(msg)
   end
 end
 

--- a/lua/efmls-configs/health/init.lua
+++ b/lua/efmls-configs/health/init.lua
@@ -1,13 +1,26 @@
-local health
+local M = {}
 
--- Keep support for nvim 0.6/0.7 but use new vim.health for nvim >= 0.8
-if vim.fn.has('nvim-0.8') == 1 then
-  health = vim.health
-else
-  health = require('health')
+---Report ok message to :checkhealth support only for nvim >= 0.8
+---@param msg string
+---@return nil
+local function report_ok(msg)
+  if vim.fn.has('nvim-0.10') == 1 then
+    vim.health.ok(msg)
+  elseif vim.fn.has('nvim-0.8') == 1 then
+    vim.health.report_ok(msg)
+  end
 end
 
-local M = {}
+---Report error message to :checkhealth support only for nvim >= 0.8
+---@param msg string
+---@return nil
+local function report_error(msg)
+  if vim.fn.has('nvim-0.10') == 1 then
+    vim.health.error(msg)
+  elseif vim.fn.has('nvim-0.8') == 1 then
+    vim.health.report_error(msg)
+  end
+end
 
 local function has_errors()
   return _G._efmls and not vim.tbl_isempty(_G._efmls.healthcheck.errors)
@@ -20,13 +33,13 @@ end
 function M.check()
   if has_errors() then
     for _, err in pairs(_G._efmls.healthcheck.errors) do
-      health.report_error(err)
+      report_error(err)
     end
   end
 
   if has_ok() then
     for _, ok in pairs(_G._efmls.healthcheck.ok) do
-      health.report_ok(ok)
+      report_ok(ok)
     end
   end
 end


### PR DESCRIPTION
In reference to #94 where the new health API introduces deprecated changes to the old API. Which in turn, causes some issues with this plugin.

Solution is to bump min support to nvim 0.7 and to add support for the new health API.