### PR TITLE
feat(linter): Add ruff config

### DIFF
--- a/lua/efmls-configs/linters/ruff.lua
+++ b/lua/efmls-configs/linters/ruff.lua
@@ -1,0 +1,23 @@
+-- Metadata
+-- languages: python
+-- url: https://github.com/astral-sh/ruff
+
+local sourceText = require('efmls-configs.utils').sourceText
+local fs = require('efmls-configs.fs')
+
+local linter = 'ruff'
+local command = string.format('%s check --stdin-filename "${INPUT}"', fs.executable(linter))
+
+return {
+  prefix = linter,
+  lintSource = sourceText(linter),
+  lintCommand = command,
+  lintStdin = true,
+  lintFormats = { '%.%#:%l:%c: %t%n %m' },
+  lintSeverity = 4,
+  rootMarkers = {
+    'ruff.toml',
+    'pyproject.toml',
+    'setup.cfg',
+  },
+}


### PR DESCRIPTION
ruff is both a [formater](https://docs.astral.sh/ruff/formatter) and a [linter](https://docs.astral.sh/ruff/linter) for Python but only the former was added in efmls-config-nvim.
This PR is an attempt at adding the linter.

I tried to replicate what I have seen in the other linters.