### PR TITLE
fix(formatter/ruff): fix args

### DIFF
--- a/lua/efmls-configs/formatters/ruff.lua
+++ b/lua/efmls-configs/formatters/ruff.lua
@@ -5,11 +5,16 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'ruff'
-local args = "check --fix-only --no-cache --stdin-filename '${INPUT}'"
+local args = "format --no-cache --stdin-filename '${INPUT}'"
 local command = string.format('%s %s', fs.executable(formatter), args)
 
 return {
   formatCommand = command,
   formatStdin = true,
-  rootMarkers = { 'pyproject.toml', 'setup.py', 'requirements.txt' },
+  rootMarkers = {
+    'pyproject.toml',
+    'setup.py',
+    'requirements.txt',
+    'ruff.toml'
+  },
 }


### PR DESCRIPTION
I suspect the command line for the ruff formatter is not suited for the newer versions of ruff.