### PR TITLE
fix(formatter/typstfmt): fix naming inconsistencies of typstfmt

### DIFF
--- a/doc/SUPPORTED_LIST.md
+++ b/doc/SUPPORTED_LIST.md
@@ -1420,10 +1420,10 @@ local xo = require('efmls-configs.formatters.xo')
 
 #### Formatters
 
-`typst` [https://github.com/astrale-sharp/typstfmt](https://github.com/astrale-sharp/typstfmt)
+`typstfmt` [https://github.com/astrale-sharp/typstfmt](https://github.com/astrale-sharp/typstfmt)
 
 ```lua
-local typst = require('efmls-configs.formatters.typst')
+local typstfmt = require('efmls-configs.formatters.typstfmt')
 ```
 
 ### Vala

--- a/doc/supported-list.json
+++ b/doc/supported-list.json
@@ -1012,7 +1012,7 @@
   "typst": {
     "formatters": [
       {
-        "name": "typst",
+        "name": "typstfmt",
         "url": "https://github.com/astrale-sharp/typstfmt"
       }
     ]


### PR DESCRIPTION
Well, I had not renamed `typst` to `typstfmt` everywhere.
This patch ensures the formatter is correctly named `typstfmt`.