### PR TITLE
feat(formatter): add deno fmt

### DIFF
--- a/lua/efmls-configs/formatters/deno-fmt.lua
+++ b/lua/efmls-configs/formatters/deno-fmt.lua
@@ -1,5 +1,5 @@
 -- Metadata
--- languages: javascript,typescript
+-- languages: javascript,typescript,javascriptreact,typescriptreact
 -- url: https://docs.deno.com/runtime/manual/tools/formatter
 
 local fs = require('efmls-configs.fs')

--- a/lua/efmls-configs/formatters/deno-fmt.lua
+++ b/lua/efmls-configs/formatters/deno-fmt.lua
@@ -1,0 +1,15 @@
+-- Metadata
+-- languages: javascript,typescript
+-- url: https://docs.deno.com/runtime/manual/tools/formatter
+
+local fs = require('efmls-configs.fs')
+
+local formatter = 'deno'
+local args = 'fmt - --ext ${FILEEXT}'
+
+local command = string.format('%s %s', fs.executable(formatter), args)
+
+return {
+  formatCommand = command,
+  formatStdin = true,
+}


### PR DESCRIPTION
- add support for https://docs.deno.com/runtime/manual/tools/formatter
- it's a simpler version of https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/lua/null-ls/builtins/formatting/deno_fmt.lua
- tested with https://github.com/ryuheechul/dotfiles/commit/7cb1713785f64d36473a49908bdc2f0bc30bc2d4#diff-8772495f3e84dbcde5cdfb3f1dacd9e27b454ab6265feaecd41528e0db987250