### PR TITLE
feat(formatter): use `biome check --apply` instead of `biome format`

### DIFF
--- a/lua/efmls-configs/formatters/biome.lua
+++ b/lua/efmls-configs/formatters/biome.lua
@@ -5,7 +5,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'biome'
-local args = "format --stdin-file-path '${INPUT}'"
+local args = "check --apply --stdin-file-path '${INPUT}'"
 local command = string.format('%s %s', fs.executable(formatter, fs.Scope.NODE), args)
 
 return {


### PR DESCRIPTION
`biome check --apply` can perform

- format
- lint fix
- organize import

although current config only supports formatting.

<https://biomejs.dev/reference/cli/#biome-check>
