### PR TITLE
feat(formatter/yapf): Support range formatting. Add setup.py to rootMarkers.

### DIFF
--- a/lua/efmls-configs/formatters/yapf.lua
+++ b/lua/efmls-configs/formatters/yapf.lua
@@ -5,10 +5,19 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'yapf'
-local command = string.format('%s', fs.executable(formatter))
+local command = string.format(
+  "%s $(echo ${--useless:rowStart} ${--useless:rowEnd} | xargs -n4 -r sh -c 'echo --lines=$(($1+1))-$(($3+1))')",
+  fs.executable(formatter)
+)
+
+local has_xargs = vim.fn.executable('xargs') == 1
+if not has_xargs then
+  command = string.format('%s', fs.executable(formatter))
+end
 
 return {
   formatCommand = command,
   formatStdin = true,
-  rootMarkers = { '.style.yapf', 'setup.cfg', 'pyproject.toml' },
+  formatCanRange = has_xargs,
+  rootMarkers = { '.style.yapf', 'setup.cfg', 'pyproject.toml', 'setup.py' },
 }


### PR DESCRIPTION
This is similar to #109 but for yapf. Unlike 7b79dfaaa40b32b3092c7b3cc872d37fc3412c66 I suggest testing existence of `xargs` directly. Though unlikely it might be absent on linux and might be present on windows.

I also added `setup.py` to `rootMarkers`.