### PR TITLE
feat(linters/phpcs): pass file path to phpcs (#137)

### DIFF
--- a/lua/efmls-configs/linters/phpcs.lua
+++ b/lua/efmls-configs/linters/phpcs.lua
@@ -6,7 +6,7 @@ local sourceText = require('efmls-configs.utils').sourceText
 local fs = require('efmls-configs.fs')
 
 local linter = 'phpcs'
-local command = string.format('%s --no-colors --report=emacs -', fs.executable(linter, fs.Scope.COMPOSER))
+local command = string.format('%s --no-colors --report=emacs --stdin-path="${INPUT}" -', fs.executable(linter, fs.Scope.COMPOSER))
 
 return {
   prefix = linter,


### PR DESCRIPTION
Pass the file path to PHPCS via `--stdin-path` to support code sniffs which rely on the file path being available.
Fixes #137 