### PR TITLE
fix(linter/clang_tidy): add lintIgnoreExitCode

### DIFF
--- a/lua/efmls-configs/linters/clang_tidy.lua
+++ b/lua/efmls-configs/linters/clang_tidy.lua
@@ -10,6 +10,7 @@ local command = string.format('%s "${INPUT}"', fs.executable(linter))
 
 return {
   prefix = linter,
+  lintIgnoreExitCode = true,
   lintSource = sourceText(linter),
   lintCommand = command,
   lintStdin = false,


### PR DESCRIPTION
Without it get these kinds of errors in LspLog
```
[ERROR][2024-09-03 22:56:01] ...lsp/handlers.lua:623    'command `/usr/bin/clang-tidy "/tmp/test.c"` exit with zero. probably you forgot to specify `lint-ignore-exit-code: true`.'
```