### PR TITLE
feat(linters): add clang_format as a linter

### DIFF
--- a/doc/SUPPORTED_LIST.md
+++ b/doc/SUPPORTED_LIST.md
@@ -156,6 +156,12 @@ local uncrustify = require('efmls-configs.formatters.uncrustify')
 
 #### Linters
 
+`clang_format` [https://clang.llvm.org/docs/ClangFormat.html](https://clang.llvm.org/docs/ClangFormat.html)
+
+```lua
+local clang_format = require('efmls-configs.linters.clang_format')
+```
+
 `clang_tidy` [http://clang.llvm.org/extra/clang-tidy/](http://clang.llvm.org/extra/clang-tidy/)
 
 ```lua
@@ -215,6 +221,12 @@ local uncrustify = require('efmls-configs.formatters.uncrustify')
 ### C
 
 #### Linters
+
+`clang_format` [https://clang.llvm.org/docs/ClangFormat.html](https://clang.llvm.org/docs/ClangFormat.html)
+
+```lua
+local clang_format = require('efmls-configs.linters.clang_format')
+```
 
 `clang_tidy` [http://clang.llvm.org/extra/clang-tidy/](http://clang.llvm.org/extra/clang-tidy/)
 

--- a/doc/supported-list.json
+++ b/doc/supported-list.json
@@ -50,6 +50,10 @@
   "c++": {
     "linters": [
       {
+        "name": "clang_format",
+        "url": "https://clang.llvm.org/docs/ClangFormat.html"
+      },
+      {
         "name": "clang_tidy",
         "url": "http://clang.llvm.org/extra/clang-tidy/"
       },
@@ -91,6 +95,10 @@
   },
   "c": {
     "linters": [
+      {
+        "name": "clang_format",
+        "url": "https://clang.llvm.org/docs/ClangFormat.html"
+      },
       {
         "name": "clang_tidy",
         "url": "http://clang.llvm.org/extra/clang-tidy/"

--- a/lua/efmls-configs/linters/clang_format.lua
+++ b/lua/efmls-configs/linters/clang_format.lua
@@ -1,0 +1,19 @@
+-- Metadata
+-- languages: c,c++
+-- url: https://clang.llvm.org/docs/ClangFormat.html
+
+local sourceText = require('efmls-configs.utils').sourceText
+local fs = require('efmls-configs.fs')
+
+local linter = 'clang-format'
+local command = string.format('%s --dry-run "${INPUT}"', fs.executable(linter))
+
+return {
+  prefix = linter,
+  lintSource = sourceText(linter),
+  lintCommand = command,
+  lintIgnoreExitCode = true,
+  lintStdin = false,
+  lintFormats = { '%f:%l:%c: %trror: %m', '%f:%l:%c: %tarning: %m', '%f:%l:%c: %tote: %m' },
+  rootMarkers = {},
+}


### PR DESCRIPTION
It is already implemented as a formatter, but I find this useful to be able to show diagnostics for formatting errors. clang-tidy seems to not cover much formatting stuff in comparison.