### PR TITLE
fix: lsp spec defines tabSize not tabWidth

### DIFF
--- a/lua/efmls-configs/formatters/prettier.lua
+++ b/lua/efmls-configs/formatters/prettier.lua
@@ -7,7 +7,7 @@ local fs = require('efmls-configs.fs')
 local formatter = 'prettier'
 local command = string.format(
   "%s --stdin --stdin-filepath '${INPUT}' ${--range-start:charStart} "
-    .. '${--range-end:charEnd} ${--tab-width:tabWidth} ${--use-tabs:!insertSpaces}',
+    .. '${--range-end:charEnd} ${--tab-width:tabSize} ${--use-tabs:!insertSpaces}',
   fs.executable(formatter, fs.Scope.NODE)
 )
 

--- a/lua/efmls-configs/formatters/prettier_d.lua
+++ b/lua/efmls-configs/formatters/prettier_d.lua
@@ -7,7 +7,7 @@ local fs = require('efmls-configs.fs')
 local formatter = 'prettierd'
 local command = string.format(
   "%s '${INPUT}' ${--range-start=charStart} ${--range-end=charEnd} "
-    .. '${--tab-width=tabWidth} ${--use-tabs=!insertSpaces}',
+    .. '${--tab-width=tabSize} ${--use-tabs=!insertSpaces}',
   fs.executable(formatter, fs.Scope.NODE)
 )
 


### PR DESCRIPTION
Not sure why those were changed from `tabSize` to `tabWidth` in https://github.com/creativenull/efmls-configs-nvim/commit/ddc7c542aaad21da594edba233c15ae3fad01ea0, but the change was wrong.

Current main generates this command
```sh
 2025/03/28 20:29:26 /nix/store/45a6c4yagzgpdckl0b88r92br4apdixv-prettier-3.5.3/bin/prettier --stdin --stdin-filepath '/Users/konrad/Code/github.com/konradmalik/neovim-flake/config/nvim/snippets/all.json'
```
understandable, because there's no such parameter as `tabWidth` defined.

while with the fix in this PR we have (notice tab-width)
```sh
2025/03/28 20:16:28 /nix/store/45a6c4yagzgpdckl0b88r92br4apdixv-prettier-3.5.3/bin/prettier --stdin --stdin-filepath '/Users/konrad/Code/github.com/konradmalik/neovim-flake/config/nvim/snippets/all.json'   --tab-width 4
```
it's added, because `tabSize` is defined.

All because when we look at nvim formatting params we see:
```lua
{
  options = {
    insertSpaces = true,
    tabSize = 4
  },
  textDocument = {
    uri = "file:///Users/konrad/Code/github.com/konradmalik/neovim-flake/config/nvim/snippets/all.json"
  }
}
```
`tabSize` is sent, not `tabWidth`.

Finally, looking at the spec https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#formattingOptions it defines `tabSize`, not `tabWidth`.