### PR TITLE
fix(linter/golangci_lint): not working with version 2

### DIFF
--- a/lua/efmls-configs/linters/golangci_lint.lua
+++ b/lua/efmls-configs/linters/golangci_lint.lua
@@ -5,8 +5,16 @@
 local sourceText = require('efmls-configs.utils').sourceText
 local fs = require('efmls-configs.fs')
 
+local outputFormat = '--out-format tab'
+local ok, versionOutput = pcall(vim.fn.system, { 'golangci-lint', 'version' })
+
+--- check if golangci-lint is version 2
+if ok and string.match(versionOutput, 'version%s+v?(2%.[%d%.]+)') then
+  outputFormat = '--output.tab.path=stdout'
+end
+
 local linter = 'golangci-lint'
-local command = string.format('%s run --color never --out-format tab "${INPUT}"', fs.executable(linter))
+local command = string.format('%s run --color never %s "${INPUT}"', fs.executable(linter), outputFormat)
 
 return {
   prefix = linter,


### PR DESCRIPTION
The `golangci_lint` is not working for version 2 since they've remove the flag `--output-format`.
Fixing this.

Reference: [nvim-lint's golangcilint config](https://github.com/mfussenegger/nvim-lint/blob/2b0039b8be9583704591a13129c600891ac2c596/lua/lint/linters/golangcilint.lua#L34)