### PR TITLE
fix(linter/eslint): eslint_d & eslint support for v9

### DIFF
--- a/lua/efmls-configs/linters/eslint_d.lua
+++ b/lua/efmls-configs/linters/eslint_d.lua
@@ -3,11 +3,29 @@
 -- url: https://github.com/mantoni/eslint_d.js
 
 local sourceText = require('efmls-configs.utils').sourceText
+local concat = require('efmls-configs.utils').concat
 local fs = require('efmls-configs.fs')
 
 local linter = 'eslint_d'
 local bin = fs.executable(linter, fs.Scope.NODE)
-local args = '--no-color --format visualstudio --stdin-filename "${INPUT}" --stdin'
+
+local format = 'visualstudio'
+local lintFormats = { '%f(%l,%c): %trror %m', '%f(%l,%c): %tarning %m' }
+local appendMarkers = {}
+local ok, versionOutput = pcall(vim.fn.system, 'eslint_d --version')
+local isVersion9 = ok and string.find(versionOutput, 'eslint: v9.')
+
+if isVersion9 then
+  format = 'stylish'
+  lintFormats = { '%-P%f', '%\\s%#%l:%c %# %trror  %m', '%\\s%#%l:%c %# %tarning  %m', '%-Q,%-G%.%#' }
+  appendMarkers = {
+    'eslint.config.cjs',
+    'eslint.config.mjs',
+    'eslint.config.js',
+  }
+end
+
+local args = '--no-color --format ' .. format .. ' --stdin-filename "${INPUT}" --stdin'
 local command = string.format('%s %s', bin, args)
 
 return {
@@ -15,9 +33,9 @@ return {
   lintSource = sourceText(linter),
   lintCommand = command,
   lintStdin = true,
-  lintFormats = { '%f(%l,%c): %trror %m', '%f(%l,%c): %tarning %m' },
+  lintFormats = lintFormats,
   lintIgnoreExitCode = true,
-  rootMarkers = {
+  rootMarkers = concat({
     '.eslintrc',
     '.eslintrc.cjs',
     '.eslintrc.js',
@@ -25,5 +43,5 @@ return {
     '.eslintrc.yaml',
     '.eslintrc.yml',
     'package.json',
-  },
+  }, appendMarkers),
 }

--- a/lua/efmls-configs/utils.lua
+++ b/lua/efmls-configs/utils.lua
@@ -7,4 +7,19 @@ M.sourceText = function(suffix)
   return string.format('efm/%s', suffix)
 end
 
+---Concatenate two tables
+---@param tbl1 table
+---@param tbl2 table
+---@return table
+M.concat = function(tbl1, tbl2)
+  local result = {}
+  for i = 1, #tbl1 do
+    result[i] = tbl1[i]
+  end
+  for i = 1, #tbl2 do
+    result[#tbl1 + i] = tbl2[i]
+  end
+  return result
+end
+
 return M


### PR DESCRIPTION
Since eslint v9 support for known formats(like unix,vscode) has been dropped and requires separate packages installation for working correctly.

Only one `--format` remains built-in and that is `stylish`.

NOTE: the `lintFormats` are being copied from - https://github.com/neovim/neovim/blob/master/runtime/compiler/eslint.vim

![image](https://github.com/user-attachments/assets/63aa1774-0eca-4326-b17a-236ab9c9de86)
