### PR TITLE
fix(formatter/sqruff): remove deprecated force arg

### DIFF
--- a/lua/efmls-configs/formatters/sqruff.lua
+++ b/lua/efmls-configs/formatters/sqruff.lua
@@ -5,7 +5,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'sqruff'
-local args = 'fix --force -'
+local args = 'fix -'
 local command = string.format('%s %s', fs.executable(formatter), args)
 
 return {


### PR DESCRIPTION
Hi there,

I noticed that the `sqruff` formatter wasn't working.
Turns out the `force` argument got dropped from the `fix` command.

I went ahead and removed it from the format command.

Seems to be working now.