### PR TITLE
changes mix format --stdin-filename value

### DIFF
--- a/lua/efmls-configs/formatters/mix.lua
+++ b/lua/efmls-configs/formatters/mix.lua
@@ -5,7 +5,7 @@
 local fs = require('efmls-configs.fs')
 
 local formatter = 'mix'
-local args = 'format --stdin-filename $FILENAME -'
+local args = 'format --stdin-filename ${INPUT} -'
 local command = string.format('%s %s', fs.executable(formatter), args)
 
 return {


### PR DESCRIPTION
mix format was incorrectly getting `$FILENAME` as it's `--stdin-filename` value instead of `${INPUT}`, which is what is specified in the EFM schema. This would result in empty output which could result in erasing your elixir files. Especially noticeable when formatting on `BufWritePre`.