### PR TITLE
Feat: add htmlhint and make it the default linter for html

### DIFF
--- a/doc/SUPPORTED_LIST.md
+++ b/doc/SUPPORTED_LIST.md
@@ -610,6 +610,12 @@ local fourmolu = require('efmls-configs.formatters.fourmolu')
 local djlint = require('efmls-configs.linters.djlint')
 ```
 
+`htmlhint` [https://htmlhint.com/](https://htmlhint.com/)
+
+```lua
+local htmlhint = require('efmls-configs.linters.htmlhint')
+```
+
 #### Formatters
 
 `djlint` [https://djlint.com/](https://djlint.com/)

--- a/doc/SUPPORTED_LIST.md
+++ b/doc/SUPPORTED_LIST.md
@@ -14,7 +14,7 @@ check the docs: [`:help efmls-configs-defaults`](../README.md#default-configurat
 | CSS/SCSS/LESS/SASS | `stylelint` | `prettier` |
 | JavaScript/JSX TypeScript/TSX | `eslint` | `prettier` |
 | Go | `golangci_lint` |  |
-| HTML |  | `prettier` |
+| HTML | `htmlhint` | `prettier` |
 | Lua | `luacheck` | `stylua` |
 | Nix |  | `alejandra` |
 | PHP | `phpcs` | `phpcbf` |

--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -182,7 +182,7 @@ Languages to support, list based on ALE with LSP servers omitted:
   + [X] [alex](https://github.com/wooorm/alex)
   + [X] [fecs](http://fecs.baidu.com/)
   + [ ] [html-beautify](https://beautifier.io/)
-  + [ ] [htmlhint](http://htmlhint.com/)
+  + [x] [htmlhint](http://htmlhint.com/)
   + [X] [prettier](https://github.com/prettier/prettier)
   + [X] [proselint](http://proselint.com/)
   + [ ] [tidy](http://www.html-tidy.org/)

--- a/doc/supported-list.json
+++ b/doc/supported-list.json
@@ -378,6 +378,10 @@
       {
         "name": "djlint",
         "url": "https://djlint.com/"
+      },
+      {
+        "name": "htmlhint",
+        "url": "https://htmlhint.com/"
       }
     ],
     "formatters": [

--- a/lua/efmls-configs/defaults.json
+++ b/lua/efmls-configs/defaults.json
@@ -19,6 +19,7 @@
     {
       "languages": ["html"],
       "alias": "HTML",
+      "linters": ["htmlhint"],
       "formatters": ["prettier"]
     },
     {

--- a/lua/efmls-configs/linters/htmlhint.lua
+++ b/lua/efmls-configs/linters/htmlhint.lua
@@ -1,0 +1,19 @@
+-- Metadata
+-- languages: html
+-- url: https://htmlhint.com
+
+local sourceText = require('efmls-configs.utils').sourceText
+local fs = require('efmls-configs.fs')
+
+local linter = 'htmlhint'
+local command = string.format('%s stdin -f compact -', fs.executable(linter))
+
+return {
+  prefix = linter,
+  lintSource = sourceText(linter),
+  lintCommand = command,
+  lintIgnoreExitCode = true,
+  lintStdin = true,
+  lintFormats = { 'stdin: line %l, col %c, %trror - %m', 'stdin: line %l, col %c, %tarning - %m' },
+  rootMarkers = {},
+}


### PR DESCRIPTION
This PR adds htmlhint as a linter for html. I also make it the default linter for html since there's no other better linter for this language yet.

Also, I was confused with two instances of HTML and html in the supported doc and json files. Is the former for the markup linter while the latter for syntax linter? Thanks.